### PR TITLE
Do not restart kubelet

### DIFF
--- a/files/01-aws-nvidia-driver.sh
+++ b/files/01-aws-nvidia-driver.sh
@@ -214,5 +214,5 @@ fi
 # Restart Kubelet
 #   Only necessary in the case of Accelerators (not Device Plugins)
 
-echo "Restarting Kubelet"
-systemctl restart kubelet.service
+#echo "Restarting Kubelet"
+#systemctl restart kubelet.service


### PR DESCRIPTION
Restaring `kubelet` causes the node to go `NotReady` and this breaks the `CA` logic that prevents it from starting multiple GPU instances when the first one comes up without exposing the GPU(s) immediately as drivers aren't installed yet.

